### PR TITLE
chore: Fix Dockerfile and add example shell script for M2

### DIFF
--- a/examples/pytorch-mobilenet-image.sh
+++ b/examples/pytorch-mobilenet-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Make sure we're running in the script's location
+DOCKER_FILE="$(realpath $(dirname $BASH_SOURCE)/../Dockerfile)"
+
+echo "Building WasmEdge-wasi-nn local image..."
+docker build -t wasmedge-wasi-nn-local -f ../Dockerfile ..
+
+
+echo "Getting WasmEdge-WASINN-examples..." 
+TMP_WASINN_WORKDIR=$(mktemp -d)
+git clone --depth 1 \
+  https://github.com/second-state/WasmEdge-WASINN-examples.git \
+  ${TMP_WASINN_WORKDIR}/WasmEdge-wasi-nn
+
+
+echo "Running the pytorch-mobilenet-image example..."
+set -x
+docker run \
+    --volume ${TMP_WASINN_WORKDIR}/WasmEdge-wasi-nn/pytorch-mobilenet-image:/example \
+    --tty \
+    --rm \
+    --interactive \
+    --workdir /example \
+    wasmedge-wasi-nn-local \
+    wasmedge \
+        --dir .:. \
+        wasmedge-wasinn-example-mobilenet-image.wasm \
+        mobilenet.pt \
+        input.jpg


### PR DESCRIPTION
Just go to examples folder and run `./pytorch-mobilenet-image.sh`

Then you get something like
```
Building WasmEdge-wasi-nn local image...
...

Getting WasmEdge-WASINN-examples...
Cloning into '/tmp/tmp.J3zSXGFAHE/WasmEdge-wasi-nn'...
...

Running the pytorch-mobilenet-image example...
+ docker run --volume /tmp/tmp.J3zSXGFAHE/WasmEdge-wasi-nn/pytorch-mobilenet-image:/example --tty --rm --interactive --workdir /example wasmedge-wasi-nn-local wasmedge --dir .:. wasmedge-wasinn-example-mobilenet-image.wasm mobilenet.pt input.jpg
Read torchscript binaries, size in bytes: 14376860
Loaded graph into wasi-nn with ID: 0
Created wasi-nn execution context with ID: 0
Read input tensor, size in bytes: 602112
Executed graph inference
   1.) [954](20.6681)banana
   2.) [940](12.1483)spaghetti squash
   3.) [951](11.5748)lemon
   4.) [950](10.4899)orange
   5.) [953](9.4834)pineapple, ananas
```

This can be extended by adding more WasmEdge plugins to the Dockerfile and also adding other scripts which mount and execute examples from the current repository (as opposed to the given example which uses the `WasmEdge-wasi-nn` examples repo).